### PR TITLE
ensure replicaCount doesn't get overridden

### DIFF
--- a/charts/vllm/Chart.yaml
+++ b/charts/vllm/Chart.yaml
@@ -6,6 +6,6 @@ description: |
 
 type: application
 
-version: 0.4.0-post1a
+version: 0.4.0-post1b
 
 appVersion: "v0.4.0.post1"

--- a/charts/vllm/templates/deployment.yaml
+++ b/charts/vllm/templates/deployment.yaml
@@ -9,7 +9,9 @@ metadata:
   labels:
     {{- include "vllm.labels" . | nindent 4 }}
 spec:
+  {{- if ne (int .Values.replicaCount) 1 }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "vllm.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
This is important when autoscaler or lingo is used. Without this change,
helm upgrade would scale down to 1 or whatever the replicaCount is set
to. This allows users to remove replicaCount from their values file and
let an autoscaler take care of it.

The default value of K8s Deployment.replicas is 1. That's why omitting
replicas if 1 is fine and why default in values.yaml is set to 1.